### PR TITLE
Chore: bump workspace-optimizer to 0.12.8

### DIFF
--- a/build_release.sh
+++ b/build_release.sh
@@ -1,4 +1,4 @@
 docker run --rm -v "$(pwd)":/code \
     --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
     --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-    cosmwasm/workspace-optimizer:0.12.6
+    cosmwasm/workspace-optimizer:0.12.8

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.60.0"
+channel = "1.63.0"


### PR DESCRIPTION
This PR also bumps Rust toolchain from 1.60.0 to 1.63.0.