### PR TITLE
Impossible relocation workaround

### DIFF
--- a/contracts/dao/pre-propose/cwd-pre-propose-single-overrule/Cargo.toml
+++ b/contracts/dao/pre-propose/cwd-pre-propose-single-overrule/Cargo.toml
@@ -28,8 +28,6 @@ thiserror = { version = "1.0.31" }
 neutron-subdao-core = { version = "*", path = "../../../../packages/neutron-subdao-core" }
 cwd-core = { version = "*", path = "../../../../contracts/dao/cwd-core", features = ["library"]  }
 neutron-subdao-timelock-single = { version = "*", path = "../../../../packages/neutron-subdao-timelock-single" }
-neutron-subdao-proposal-single = { version = "*", path = "../../../../packages/neutron-subdao-proposal-single" }
-neutron-subdao-pre-propose-single = { version = "*", path = "../../../../packages/neutron-subdao-pre-propose-single" }
 neutron-dao-pre-propose-overrule = { version = "*", path = "../../../../packages/neutron-dao-pre-propose-overrule" }
 cwd-proposal-single = { version = "*", path = "../../../../contracts/dao/proposal/cwd-proposal-single", features = ["library"]  }
 

--- a/contracts/dao/pre-propose/cwd-pre-propose-single-overrule/src/contract.rs
+++ b/contracts/dao/pre-propose/cwd-pre-propose-single-overrule/src/contract.rs
@@ -84,7 +84,11 @@ pub fn execute(
             // We need this check since the timelock contract might be an impostor
             // E.g. the timelock contract might be a malicious contract that is not a part of
             // the subdao but pretends to be.
-            if !verify_is_timelock_from_subdao(&deps, &subdao_address, timelock_contract_addr.clone())? {
+            if !verify_is_timelock_from_subdao(
+                &deps,
+                &subdao_address,
+                timelock_contract_addr.clone(),
+            )? {
                 return Err(PreProposeOverruleError::SubdaoMisconfigured {});
             }
 
@@ -175,7 +179,7 @@ fn verify_is_timelock_from_subdao(
     subdao_core: &Addr,
     expected_timelock: Addr,
 ) -> StdResult<bool> {
-    return deps.querier.query_wasm_smart(
+    deps.querier.query_wasm_smart(
         subdao_core,
         &SubdaoQueryMsg::VerifyTimelock {
             timelock: expected_timelock.to_string(),

--- a/contracts/dao/pre-propose/cwd-pre-propose-single-overrule/src/contract.rs
+++ b/contracts/dao/pre-propose/cwd-pre-propose-single-overrule/src/contract.rs
@@ -22,12 +22,7 @@ use cwd_core::{msg::QueryMsg as MainDaoQueryMsg, query::SubDao};
 use cwd_proposal_single::{
     msg::ExecuteMsg as ProposeMessageInternal, msg::QueryMsg as ProposalSingleQueryMsg,
 };
-use cwd_voting::pre_propose::ProposalCreationPolicy;
 use neutron_subdao_core::{msg::QueryMsg as SubdaoQueryMsg, types as SubdaoTypes};
-use neutron_subdao_pre_propose_single::msg::{
-    QueryExt as SubdaoPreProposeQueryExt, QueryMsg as SubdaoPreProposeQueryMsg,
-};
-use neutron_subdao_proposal_single::msg as SubdaoProposalMsg;
 use neutron_subdao_timelock_single::{msg as TimelockMsg, types as TimelockTypes};
 
 pub(crate) const CONTRACT_NAME: &str = "crates.io:cwd-pre-propose-single-overrule";
@@ -89,7 +84,7 @@ pub fn execute(
             // We need this check since the timelock contract might be an impostor
             // E.g. the timelock contract might be a malicious contract that is not a part of
             // the subdao but pretends to be.
-            if !verify_is_timelock_from_subdao(&deps, &subdao_address, &timelock_contract_addr)? {
+            if !verify_is_timelock_from_subdao(&deps, &subdao_address, timelock_contract_addr.clone())? {
                 return Err(PreProposeOverruleError::SubdaoMisconfigured {});
             }
 
@@ -178,37 +173,14 @@ fn get_subdao_from_timelock(
 fn verify_is_timelock_from_subdao(
     deps: &DepsMut,
     subdao_core: &Addr,
-    expected_timelock: &Addr,
-) -> Result<bool, PreProposeOverruleError> {
-    let proposal_modules: Vec<SubdaoTypes::ProposalModule> = deps.querier.query_wasm_smart(
+    expected_timelock: Addr,
+) -> StdResult<bool> {
+    return deps.querier.query_wasm_smart(
         subdao_core,
-        // we do no pagination here since it either fits in tx by gas or not
-        &SubdaoQueryMsg::ProposalModules {
-            start_after: None,
-            limit: None,
+        &SubdaoQueryMsg::VerifyTimelock {
+            timelock: expected_timelock.to_string(),
         },
-    )?;
-
-    for proposal_module in proposal_modules {
-        let prop_policy: ProposalCreationPolicy = deps.querier.query_wasm_smart(
-            proposal_module.address,
-            &SubdaoProposalMsg::QueryMsg::ProposalCreationPolicy {},
-        )?;
-        if let ProposalCreationPolicy::Module { addr } = prop_policy {
-            if let Ok(timelock) = deps.querier.query_wasm_smart::<Addr>(
-                addr,
-                &SubdaoPreProposeQueryMsg::QueryExtension {
-                    msg: SubdaoPreProposeQueryExt::TimelockAddress {},
-                },
-            ) {
-                if *expected_timelock == timelock {
-                    return Ok(true);
-                }
-            }
-        }
-    }
-
-    Ok(false)
+    )
 }
 
 fn is_subdao_legit(deps: &DepsMut, subdao_core: &Addr) -> Result<bool, PreProposeOverruleError> {

--- a/contracts/dao/pre-propose/cwd-pre-propose-single-overrule/src/testing/mock_querier.rs
+++ b/contracts/dao/pre-propose/cwd-pre-propose-single-overrule/src/testing/mock_querier.rs
@@ -165,9 +165,9 @@ impl ContractQuerier for MockSubdaoCoreQueries {
     fn query(&self, msg: &Binary) -> QuerierResult {
         let q: SubdaoQueryMsg = from_binary(msg).unwrap();
         match q {
-            SubdaoQueryMsg::VerifyTimelock {
-                timelock,
-            } => SystemResult::Ok(ContractResult::from(to_binary(&(timelock == self.timelock)))),
+            SubdaoQueryMsg::VerifyTimelock { timelock } => SystemResult::Ok(ContractResult::from(
+                to_binary(&(timelock == self.timelock)),
+            )),
             SubdaoQueryMsg::Config {} => {
                 SystemResult::Ok(ContractResult::from(to_binary(&SubdaoTypes::Config {
                     name: SUBDAO_NAME.to_string(),

--- a/contracts/subdaos/cwd-subdao-core/src/contract.rs
+++ b/contracts/subdaos/cwd-subdao-core/src/contract.rs
@@ -400,6 +400,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
         }
         QueryMsg::DaoURI {} => query_dao_uri(deps),
         QueryMsg::MainDao {} => query_main_dao(deps),
+        QueryMsg::VerifyTimelock { timelock } => query_verify_timelock(deps, timelock),
     }
 }
 
@@ -593,6 +594,13 @@ pub fn query_dao_uri(deps: Deps) -> StdResult<Binary> {
 pub fn query_main_dao(deps: Deps) -> StdResult<Binary> {
     let config = CONFIG.load(deps.storage)?;
     to_binary(&config.main_dao)
+}
+
+pub fn query_verify_timelock(deps: Deps, timelock: String) -> StdResult<Binary> {
+    to_binary(&match execution_access_check(deps, deps.api.addr_validate(&timelock)?) {
+        Ok(_) => {true}
+        Err(_) => {false}
+    })
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/subdaos/cwd-subdao-core/src/contract.rs
+++ b/contracts/subdaos/cwd-subdao-core/src/contract.rs
@@ -597,10 +597,7 @@ pub fn query_main_dao(deps: Deps) -> StdResult<Binary> {
 }
 
 pub fn query_verify_timelock(deps: Deps, timelock: String) -> StdResult<Binary> {
-    to_binary(&match execution_access_check(deps, deps.api.addr_validate(&timelock)?) {
-        Ok(_) => {true}
-        Err(_) => {false}
-    })
+    to_binary(&(execution_access_check(deps, deps.api.addr_validate(&timelock)?).is_ok()))
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/packages/neutron-subdao-core/src/msg.rs
+++ b/packages/neutron-subdao-core/src/msg.rs
@@ -137,6 +137,10 @@ pub enum QueryMsg {
     DaoURI {},
     /// Gets main dao address
     MainDao {},
+    /// Verify timelock. Returns bool.
+    VerifyTimelock {
+        timelock: String,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]

--- a/packages/neutron-subdao-core/src/msg.rs
+++ b/packages/neutron-subdao-core/src/msg.rs
@@ -138,9 +138,7 @@ pub enum QueryMsg {
     /// Gets main dao address
     MainDao {},
     /// Verify timelock. Returns bool.
-    VerifyTimelock {
-        timelock: String,
-    },
+    VerifyTimelock { timelock: String },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]


### PR DESCRIPTION
This PR just moves the checking if a timelock contract corresponds to subdao from overrule pre-proposal code to subdao core itself