### PR TITLE
fix: allow for execution of proposals that have closed overrule proposal #ntrn-225

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "cwd-subdao-timelock-single"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",

--- a/contracts/subdaos/cwd-subdao-timelock-single/Cargo.toml
+++ b/contracts/subdaos/cwd-subdao-timelock-single/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cwd-subdao-timelock-single"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Andrei Zavgorodnii <andrei.z@p2p.org>"]
 edition = "2021"
 repository = "https://github.com/neutron-org/neutron-dao"

--- a/contracts/subdaos/cwd-subdao-timelock-single/src/contract.rs
+++ b/contracts/subdaos/cwd-subdao-timelock-single/src/contract.rs
@@ -344,6 +344,7 @@ pub fn migrate(deps: DepsMut, env: Env, _msg: MigrateMsg) -> Result<Response, Co
         .into_iter()
         .map(|(_, proposal)| proposal)
         .collect();
+    let mut res: Vec<String> = vec![];
     for mut item in props {
         let overrule_proposal_id: u64 = deps.querier.query_wasm_smart(
             &config.overrule_pre_propose,
@@ -367,11 +368,12 @@ pub fn migrate(deps: DepsMut, env: Env, _msg: MigrateMsg) -> Result<Response, Co
 
         if overrule_proposal.proposal.status == Status::Closed {
             item.status = ProposalStatus::Overruled;
+            res.push(item.id.to_string());
             PROPOSALS.save(deps.storage, item.id, &item)?;
         }
     }
 
-    Ok(Response::default())
+    Ok(Response::default().add_attribute("migrated_proposal_ids", res.join(",")))
 }
 
 fn is_overrule_proposal_denied(

--- a/contracts/subdaos/cwd-subdao-timelock-single/src/contract.rs
+++ b/contracts/subdaos/cwd-subdao-timelock-single/src/contract.rs
@@ -159,7 +159,7 @@ pub fn execute_execute_proposal(
         });
     }
 
-    if !is_overrule_proposal_rejected(&deps, &env, &config.overrule_pre_propose, proposal.id)? {
+    if !is_overrule_proposal_denied(&deps, &env, &config.overrule_pre_propose, proposal.id)? {
         return Err(ContractError::TimeLocked {});
     }
 
@@ -339,7 +339,7 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
     Ok(Response::default())
 }
 
-fn is_overrule_proposal_rejected(
+fn is_overrule_proposal_denied(
     deps: &DepsMut,
     env: &Env,
     overrule_pre_propose: &Addr,
@@ -363,7 +363,8 @@ fn is_overrule_proposal_rejected(
             proposal_id: overrule_proposal_id,
         },
     )?;
-    Ok(overrule_proposal.proposal.status == Status::Rejected)
+    Ok(overrule_proposal.proposal.status == Status::Rejected
+        || overrule_proposal.proposal.status == Status::Closed)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/subdaos/cwd-subdao-timelock-single/src/contract.rs
+++ b/contracts/subdaos/cwd-subdao-timelock-single/src/contract.rs
@@ -345,7 +345,6 @@ pub fn migrate(deps: DepsMut, env: Env, _msg: MigrateMsg) -> Result<Response, Co
         .map(|(_, proposal)| proposal)
         .collect();
     let mut migrated_ids: Vec<String> = vec![];
-    let mut overrule_statuses: Vec<String> = vec![];
     for mut item in props {
         let overrule_proposal_id: u64 = deps.querier.query_wasm_smart(
             &config.overrule_pre_propose,
@@ -366,11 +365,6 @@ pub fn migrate(deps: DepsMut, env: Env, _msg: MigrateMsg) -> Result<Response, Co
                 proposal_id: overrule_proposal_id,
             },
         )?;
-        overrule_statuses.push(format!(
-            "{:?}:{:?}",
-            overrule_proposal.id.to_string(),
-            overrule_proposal.proposal.status.to_string()
-        ));
 
         if overrule_proposal.proposal.status == Status::Closed {
             item.status = ProposalStatus::Overruled;
@@ -379,9 +373,7 @@ pub fn migrate(deps: DepsMut, env: Env, _msg: MigrateMsg) -> Result<Response, Co
         }
     }
 
-    Ok(Response::default()
-        .add_attribute("migrated_proposal_ids", migrated_ids.join(","))
-        .add_attribute("migrated_overrule_statuses", overrule_statuses.join(",")))
+    Ok(Response::default().add_attribute("migrated_proposal_ids", migrated_ids.join(",")))
 }
 
 fn is_overrule_proposal_denied(

--- a/packages/cwd-pre-propose-base/src/execute.rs
+++ b/packages/cwd-pre-propose-base/src/execute.rs
@@ -303,7 +303,7 @@ where
 
         // Save the deposit.
         //
-        // It is possibe that a malicious proposal hook could run
+        // It is possible that a malicious proposal hook could run
         // before us and update our config! We don't have to worry
         // about this though as the only way to be able to update our
         // config is to have root on the code module and if someone


### PR DESCRIPTION
Rejected overrule proposals can be moved to closed state. That means we need to check for Closed state as well as rejected.

Task: https://hadronlabs.atlassian.net/browse/NTRN-225
Related PR's:
- https://github.com/neutron-org/neutron-dao/pull/100
- https://github.com/neutron-org/dao-ops/pull/27
- https://github.com/neutron-org/neutron-integration-tests/pull/268