### PR TITLE
fix: audit

### DIFF
--- a/contracts/dao/neutron-chain-manager/src/contract.rs
+++ b/contracts/dao/neutron-chain-manager/src/contract.rs
@@ -231,9 +231,10 @@ fn check_proposal_execute_message(
 
     if typed_proposal.type_field.as_str() == MSG_TYPE_UPDATE_PARAMS_CRON {
         check_cron_update_msg_params(deps, strategy, proposal)?;
+        Ok(())
+    } else {
+        Err(ContractError::Unauthorized {})
     }
-
-    Ok(())
 }
 /// Checks that the strategy owner is authorised to change the parameters of the
 /// cron module. We query the current values for each parameter & compare them to


### PR DESCRIPTION
This PR combines all the audit fixes for the privileged subdaos feature.

Complete list of fixes:

1. For `ProposalExecuteMessage`, any unknown message type could be executed because the `check_proposal_execute_message()` function returned an `Ok(())` instead of an error. This was fixed, and a test was added for this case.