### PR TITLE
feat: add and remove schedule msgs can be modified in chain manager #ntrn-387

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 [[package]]
 name = "astroport"
 version = "2.0.0"
-source = "git+https://github.com/neutron-org/neutron-tge-contracts.git?branch=main#cd7c02e8894b1953cc73c299c51010fe758a05f3"
+source = "git+https://github.com/neutron-org/neutron-tge-contracts.git?branch=main#3685cd8f9a70a70eee83c8e688c306096a68c782"
 dependencies = [
  "cosmwasm-schema 1.5.5",
  "cosmwasm-std 1.5.2",
@@ -63,7 +63,7 @@ dependencies = [
 [[package]]
 name = "astroport"
 version = "2.0.0"
-source = "git+https://github.com/neutron-org/neutron-tge-contracts.git#cd7c02e8894b1953cc73c299c51010fe758a05f3"
+source = "git+https://github.com/neutron-org/neutron-tge-contracts.git#3685cd8f9a70a70eee83c8e688c306096a68c782"
 dependencies = [
  "cosmwasm-schema 1.5.5",
  "cosmwasm-std 1.5.2",
@@ -164,7 +164,7 @@ dependencies = [
 [[package]]
 name = "astroport-periphery"
 version = "1.1.0"
-source = "git+https://github.com/neutron-org/neutron-tge-contracts.git?branch=main#cd7c02e8894b1953cc73c299c51010fe758a05f3"
+source = "git+https://github.com/neutron-org/neutron-tge-contracts.git?branch=main#3685cd8f9a70a70eee83c8e688c306096a68c782"
 dependencies = [
  "astroport 3.11.0",
  "cosmwasm-schema 1.5.5",
@@ -3149,7 +3149,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vesting-base"
 version = "1.1.0"
-source = "git+https://github.com/neutron-org/neutron-tge-contracts.git?branch=main#cd7c02e8894b1953cc73c299c51010fe758a05f3"
+source = "git+https://github.com/neutron-org/neutron-tge-contracts.git?branch=main#3685cd8f9a70a70eee83c8e688c306096a68c782"
 dependencies = [
  "astroport 2.0.0 (git+https://github.com/neutron-org/neutron-tge-contracts.git?branch=main)",
  "cosmwasm-schema 1.5.5",
@@ -3179,7 +3179,7 @@ dependencies = [
 [[package]]
 name = "vesting-base"
 version = "1.1.0"
-source = "git+https://github.com/neutron-org/neutron-tge-contracts.git#cd7c02e8894b1953cc73c299c51010fe758a05f3"
+source = "git+https://github.com/neutron-org/neutron-tge-contracts.git#3685cd8f9a70a70eee83c8e688c306096a68c782"
 dependencies = [
  "astroport 2.0.0 (git+https://github.com/neutron-org/neutron-tge-contracts.git)",
  "cosmwasm-schema 1.5.5",
@@ -3206,7 +3206,7 @@ dependencies = [
 [[package]]
 name = "vesting-lp"
 version = "1.2.0"
-source = "git+https://github.com/neutron-org/neutron-tge-contracts.git?branch=main#cd7c02e8894b1953cc73c299c51010fe758a05f3"
+source = "git+https://github.com/neutron-org/neutron-tge-contracts.git?branch=main#3685cd8f9a70a70eee83c8e688c306096a68c782"
 dependencies = [
  "astroport 2.0.0 (git+https://github.com/neutron-org/neutron-tge-contracts.git?branch=main)",
  "cosmwasm-schema 1.5.5",
@@ -3221,7 +3221,7 @@ dependencies = [
 [[package]]
 name = "vesting-lp-pcl"
 version = "1.1.0"
-source = "git+https://github.com/neutron-org/neutron-tge-contracts.git?branch=main#cd7c02e8894b1953cc73c299c51010fe758a05f3"
+source = "git+https://github.com/neutron-org/neutron-tge-contracts.git?branch=main#3685cd8f9a70a70eee83c8e688c306096a68c782"
 dependencies = [
  "astroport 2.0.0 (git+https://github.com/neutron-org/neutron-tge-contracts.git?branch=main)",
  "cosmwasm-schema 1.5.5",

--- a/contracts/dao/neutron-chain-manager/src/contract.rs
+++ b/contracts/dao/neutron-chain-manager/src/contract.rs
@@ -180,6 +180,16 @@ fn check_neutron_msg(
     neutron_msg: NeutronMsg,
 ) -> Result<(), ContractError> {
     match neutron_msg {
+        NeutronMsg::AddSchedule { .. } => {
+            if !strategy.has_cron_add_schedule_permission() {
+                return Err(ContractError::Unauthorized {});
+            }
+        }
+        NeutronMsg::RemoveSchedule { name: _ } => {
+            if !strategy.has_cron_remove_schedule_permission() {
+                return Err(ContractError::Unauthorized {});
+            }
+        }
         NeutronMsg::SubmitAdminProposal { admin_proposal } => {
             check_submit_admin_proposal_message(deps, strategy, admin_proposal)?;
         }

--- a/contracts/dao/neutron-chain-manager/src/cron_module_types.rs
+++ b/contracts/dao/neutron-chain-manager/src/cron_module_types.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 
 pub const PARAMS_QUERY_PATH_CRON: &str = "/neutron.cron.Query/Params";
 pub const MSG_TYPE_UPDATE_PARAMS_CRON: &str = "/neutron.cron.MsgUpdateParams";
+pub const MSG_TYPE_ADD_SCHEDULE: &str = "/neutron.cron.MsgAddSchedule";
+pub const MSG_TYPE_REMOVE_SCHEDULE: &str = "/neutron.cron.MsgRemoveSchedule";
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/contracts/dao/neutron-chain-manager/src/lib.rs
+++ b/contracts/dao/neutron-chain-manager/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod contract;
-mod cron_module_param_types;
+mod cron_module_types;
 mod dex_module_param_types;
 mod error;
 pub mod msg;

--- a/contracts/dao/neutron-chain-manager/src/testing/mock_querier.rs
+++ b/contracts/dao/neutron-chain-manager/src/testing/mock_querier.rs
@@ -1,4 +1,4 @@
-use crate::cron_module_param_types::{ParamsCron, ParamsResponseCron};
+use crate::cron_module_types::{ParamsCron, ParamsResponseCron};
 use crate::dex_module_param_types::{ParamsDex, ParamsResponseDex};
 use crate::tokenfactory_module_param_types::{ParamsResponseTokenfactory, ParamsTokenfactory};
 use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage};


### PR DESCRIPTION
[TASK](https://hadronlabs.atlassian.net/browse/NTRN-387)

PR's:
- https://github.com/neutron-org/neutron-dao/pull/113 - allows to send addSchedule removeSchedule through allowOnly strategy
- https://github.com/neutron-org/neutron/pull/710
- https://github.com/neutron-org/neutron-integration-tests/pull/342 - tests allow only strategy works
- https://github.com/neutron-org/neutronjsplus/pull/57 - add proposal types for MsgAddSchedule/MsgRemoveSchedule